### PR TITLE
Add support for Elasticsearch/Kibana

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 wp-content/
 logs/
+.vscode/
+elasticsearch-data/

--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ This project sets up a Docker-based testing environment for WooCommerce, allowin
    - The WordPress site at `http://localhost:8080`
    - The frontend dashboard at `http://localhost:3000`
 
+5. To configure Kibana to provide a search UI for collected HTTP requests, perform the following
+   1. Ensure that at least one outbound HTTP request has been issued from the WordPress install
+      1. This can be triggered from the [Plugins > Add New Plugin](http://localhost:8080/wp-admin/plugin-install.php) page
+   2. Open the Kibana dashboard at <http://localhost:5601>
+   3. Navigate to the Stack Management page in the main sidebar
+   4. Navigate to [Kibana > Data Views](http://localhost:5601/app/management/kibana/dataViews) in the Management sidebar
+   5. Click `Create data view`
+   6. Provide a name for the data view
+   7. Set `Index pattern` to `api-calls`
+   8. Set `Timestamp field`
+   9. The data view will now be available when navigating to the [Analytics > Discover](http://localhost:5601/app/discover) page in the main sidebar
+
+<!-- Github admonition syntax - see https://github.com/orgs/community/discussions/16925 -->
+> [!NOTE]
+> In the future, the Kibana data view will be automatically created
+
 ## Frontend Dashboard
 
 The frontend dashboard provides an easy-to-use interface for managing your WooCommerce testing sandbox. It offers the following features:
@@ -72,6 +88,11 @@ To use the plugin installation feature:
 - Captures network traffic related to API calls.
 - Processes the captured data every 5 minutes.
 - Generates a CSV file (`/logs/api_calls.csv`) with information about the API calls, including the plugin that made the call, the endpoint, the HTTP method, and the timestamp.
+
+### ElasticSearch and Kibana Containers
+
+- Stores data about HTTP requests made using the WordPress HTTP API
+- Provide a frontend to browse/search captured HTTP request data
 
 ## Analyzing Results
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       WORDPRESS_ADMIN_USER: admin
       WORDPRESS_ADMIN_PASSWORD: password
       WORDPRESS_ADMIN_EMAIL: admin@example.com
+      ELASTICSEARCH_URL: http://elasticsearch:9200
     volumes:
       - ./wp-content:/var/www/html/wp-content
       - ./source-file-interceptor:/var/www/html/wp-content/plugins/source-file-interceptor
@@ -25,6 +26,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - db
+      - elasticsearch
 
   db:
     image: mariadb:10.5
@@ -57,6 +59,30 @@ services:
       - ./logs:/usr/share/nginx/html/logs
     depends_on:
       - wordpress
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.2
+    container_name: elasticsearch
+    restart: always
+    environment:
+      - xpack.security.enabled=false
+      - discovery.type=single-node
+    cap_add:
+      - IPC_LOCK
+    volumes:
+      - ./elasticsearch-data:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+  kibana:
+    container_name: kibana
+    image: docker.elastic.co/kibana/kibana:8.15.2
+    restart: always
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200    # address of elasticsearch docker container which kibana will connect
+    ports:
+      - 5601:5601
+    depends_on:
+      - elasticsearch                                   # kibana will start when elasticsearch has started
 
 volumes:
   db_data:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -139,6 +139,13 @@
             class="text-blue-500 hover:underline"
             >Download CSV</a
           >
+          <br/>
+          <a
+            href="http://localhost:5601"
+            target="_blank"
+            class="text-blue-500 hover:underline"
+            >Kibana dashboard</a
+          >
         </div>
       </div>
       <div class="mt-6 bg-white rounded-lg shadow-md p-6">

--- a/source-file-interceptor/source-file-interceptor.php
+++ b/source-file-interceptor/source-file-interceptor.php
@@ -82,6 +82,10 @@ function run_source_file_interceptor() {
 run_source_file_interceptor();
 
 function inject_source_ctx($parsed_args, $url) {
+	if (str_starts_with($url, $_ENV['ELASTICSEARCH_URL'])) {
+		return $parsed_args;
+	}
+
     $e = new \Exception();
 	$traceString = $e->getTraceAsString();
 	$trace = preg_split("/\r\n|\n|\r/", $traceString);
@@ -105,11 +109,37 @@ function inject_source_ctx($parsed_args, $url) {
 			header("X-Source-File: {$srcFile}");
 			header("X-Source-Line: {$srcLine}");
 
+			$dt = new DateTime();
+			$iso8601 = $dt->format(DateTime::ATOM);
+			$payload = array(
+				'wp_remote_func' => $func,
+				'request_uri' => $url,
+				'method' => $parsed_args['method'],
+				'source_file' => $srcFile,
+				'source_line' => $srcLine,
+				'timestamp' => $iso8601,
+			);
 
 			error_log("Detected call to {$func} in file {$srcFile}, line {$srcLine}");
+
+
+
+			$res = wp_remote_post(
+				"{$_ENV['ELASTICSEARCH_URL']}/api-calls/_doc",
+				array (
+					'headers' => array('Content-Type' => 'application/json; charset=utf-8'),
+					'body' => json_encode($payload),
+					'method' => 'POST',
+					'data_format' => 'body',
+				)
+			);
+			error_log(var_export($res, true));
 		}
 	}
+
+
+
 	return $parsed_args;
 }
 
-add_filter('http_request_args', 'inject_source_ctx', 10, 3);
+add_filter('http_request_args', 'inject_source_ctx', 999, 3);


### PR DESCRIPTION
This changeset adds Elasticsearch and Kibana to the fakewoo setup, for storing and searching outgoing HTTP requests

Due to the fact that tcpdump cannot inspect the contents of encrypted requests, the processing is now done via the `http_request_args` hook provided by WordPress. As such, it can only inspect HTTP requests made via the WordPress HTTP API (e.g. `wp_remote_*`). Requests from other HTTP APIs may not be captured.